### PR TITLE
Fix screenshot in installation docs

### DIFF
--- a/resources/collection.md
+++ b/resources/collection.md
@@ -4,13 +4,13 @@ In the Collection tab you can browse all cards available in the game. We try to 
 
 In this tab you can find any card, be it by text search or by using the column filters. One commonly used filter is the boosters filter:
 
-![Boosters Filter](collection-filter-boosters)
+![Boosters Filter](../../images/docs/collection-filter-boosters.png)
 
 Enable the Red marker to allow *any* card to show in the results. Enable the Green marker to allow cards that can only be obtained by cracking booster packs. 
 
 You can also change the View mode to see different aspects of your collection. For example, using the Sets View allows you to see in detail how many boosters you need to open to complete sets, or know (approximately) how many drafts you have to play before you can start cracking packs, to optimize the ammount of play you need in order to complete all mythics or rares in each set:
 
-![Sets View](collection-view-sets)
+![Sets View](../../images/docs/collection-view-sets.png)
 
 Depending on the filters you set all parts of the Collection tab will update to represent them. For example, selecting just one Set will make the right side panel show the statistics only for that set. The same applies for any other filter like colors, rarity and even text search.
 

--- a/resources/decks.md
+++ b/resources/decks.md
@@ -2,12 +2,12 @@
 
 Here you will find all decks you have with in MTG Arena.
 
-![Archive Deck](deck-archive)
+![Archive Deck](../../images/docs/deck-archive.png)
 
 You can open any deck to see common stats like mana curve, types count and wildcards. You can also export and share that deck in this screen.
 
 Once open, on the right side panel you can see this deck's winrate and statistics based on the filters set on the previous screen (but only for this deck)
 
-![Deck View](deck-view)
+![Deck View](../../images/docs/deck-view.png)
 
 > **Note:** The "Export to .txt" button will export on the format set in Settings > Behaviour > "Export Format", while the "Export to Arena" button will copy the deck to the clipboard so you can paste it into Arena.

--- a/resources/installation.md
+++ b/resources/installation.md
@@ -10,7 +10,7 @@ For Mac users we provide `.dmg` installers, but we currently cannot actively sup
 
 On all platforms, before you can run any software for MTG Arena you need to enable "plugins support" on it. To do so, open the game and navigate to your settings, and on "Account" enable "Detailed Logs (Plugin Support)", as shown below.
 
-![Detailed logs](detailed-logs)
+![Detailed logs](../../images/docs/detailed-logs.png)
 
 Once you do this close MTG Arena and start again so the game generates a new valid log the tracker can read. (else the tracker will still ask you to do this)
 


### PR DESCRIPTION
The link was broken and pointed to nothing. The correct location is https://mtgatool.com/images/docs/detailed-logs.png and the page itself is at https://mtgatool.com/docs/installation.